### PR TITLE
Support table name with schema for postgres in Yaml

### DIFF
--- a/fixtures/test_fixtures3.yml
+++ b/fixtures/test_fixtures3.yml
@@ -1,0 +1,8 @@
+- table: 'schema.some_table'
+  pk:
+    id: 1
+  fields:
+    string_field: 'foobar'
+    boolean_field: true
+    created_at: 'ON_INSERT_NOW()'
+    updated_at: 'ON_UPDATE_NOW()'

--- a/load.go
+++ b/load.go
@@ -38,6 +38,23 @@ func Load(data []byte, db *sql.DB, driver string) error {
 		// Load internat struct variables
 		row.Init()
 
+		s := strings.Split(row.Table, ".")
+		switch {
+			case len(s) > 2:
+				return fmt.Errorf("Table name wrong format in yaml")
+			case len(s) == 2:
+				q := fmt.Sprintf(`SET SEARCH_PATH TO %s`, s[0])
+				_, err := tx.Exec(q)
+				if err != nil {
+					tx.Rollback() // rollback the transaction
+					return NewProcessingError(i+1, err)
+				}
+				row.Table = s[1]
+			case len(s) == 1:
+				// table name without schema, do nothing
+			default:
+				return fmt.Errorf("Table nmae is empty in yaml")
+		}
 		// Run a SELECT query to find out if we need to insert or UPDATE
 		selectQuery := fmt.Sprintf(
 			`SELECT COUNT(*) FROM "%s" WHERE %s`,

--- a/load_test.go
+++ b/load_test.go
@@ -59,7 +59,7 @@ CREATE TABLE string_key_table(
   updated_at TIMESTAMP WITH TIME ZONE
 );
 
-CREATE TABLE api.some_table(
+CREATE TABLE schema.some_table(
   id INT PRIMARY KEY NOT NULL,
   string_field VARCHAR(50) NOT NULL,
   boolean_field BOOL NOT NULL,
@@ -96,7 +96,7 @@ var testData = `
   fields:
     created_at: 'ON_INSERT_NOW()'
     updated_at: 'ON_UPDATE_NOW()'
-- table: 'api.some_table'
+- table: 'schema.some_table'
   pk:
     id: 1
   fields:

--- a/load_test.go
+++ b/load_test.go
@@ -58,6 +58,14 @@ CREATE TABLE string_key_table(
   created_at TIMESTAMP WITH TIME ZONE,
   updated_at TIMESTAMP WITH TIME ZONE
 );
+
+CREATE TABLE api.some_table(
+  id INT PRIMARY KEY NOT NULL,
+  string_field VARCHAR(50) NOT NULL,
+  boolean_field BOOL NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE,
+  updated_at TIMESTAMP WITH TIME ZONE
+);
 `
 
 var testData = `
@@ -88,6 +96,14 @@ var testData = `
   fields:
     created_at: 'ON_INSERT_NOW()'
     updated_at: 'ON_UPDATE_NOW()'
+- table: 'api.some_table'
+  pk:
+    id: 1
+  fields:
+    string_field: 'foobar'
+    boolean_field: true
+    created_at: 'ON_INSERT_NOW()'
+    updated_at: 'ON_UPDATE_NOW()'
 `
 
 var (
@@ -95,5 +111,6 @@ var (
 	fixtureFiles = []string{
 		"fixtures/test_fixtures1.yml",
 		"fixtures/test_fixtures2.yml",
+		"fixtures/test_fixtures3.yml",
 	}
 )


### PR DESCRIPTION
Currently, the table name in Yaml doesn't support schema. This pr is to support load data into a different schema than `public` in progress. 
For example:
```yaml
- table: 'schema.some_table'
  pk:
    id: 1
  fields:
    string_field: 'foobar'
    boolean_field: true
    created_at: 'ON_INSERT_NOW()'
    updated_at: 'ON_UPDATE_NOW()'
```